### PR TITLE
feat(i18n): unify translations for buttons, perks, eco-log

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,12 +98,12 @@ const selectByRarity = (speciesPool) => {
     return speciesPool[speciesPool.length - 1];
 };
 const EcoLogComponent = ({ ecoLog, onBack }) => {
-    const { t, tNested } = useTranslation();
+    const { tNested } = useTranslation();
     return (
         <div className="screen-container">
-            <h1>{t('screens.ecoLog.title')}</h1>
+            <h1>{tNested('screens.ecoLog.title')}</h1>
             <p style={{ textAlign: 'center', color: 'var(--light-text)', maxWidth: '600px', marginBottom: '2rem' }}>
-                {t('screens.ecoLog.description')}
+                {tNested('screens.ecoLog.description')}
             </p>
             <div className="screen-grid">
                 {speciesData.map(species => {
@@ -113,33 +113,33 @@ const EcoLogComponent = ({ ecoLog, onBack }) => {
                     return (
                         <div key={species.id} className={`card ${isDiscovered ? 'discovered' : 'undiscovered'}`}>
                             <div className="emoji">{isDiscovered ? species.emoji : '❓'}</div>
-                            <h3>{isDiscovered ? speciesName : t('gameUI.undiscovered')}</h3>
+                            <h3>{isDiscovered ? speciesName : tNested('gameUI.undiscovered')}</h3>
                             {isDiscovered ? (
                                 <>
-                                    <p>{t('gameUI.level')}: {entry.researchLevel} / {MAX_RESEARCH_LEVEL}</p>
-                                    <p>{t('gameUI.rarity')}: {t(`rarity.${species.rarity}`)}</p>
+                                    <p>{tNested('gameUI.level')}: {entry.researchLevel} / {MAX_RESEARCH_LEVEL}</p>
+                                    <p>{tNested('gameUI.rarity')}: {tNested(`rarity.${species.rarity}`)}</p>
                                     <div className="xp-bar-container" title={`XP: ${entry.researchXp} / ${XP_PER_LEVEL}`}>
                                         <div className="xp-bar-fill" style={{ width: `${(entry.researchXp / XP_PER_LEVEL) * 100}%` }}></div>
                                     </div>
                                 </>
                             ) : (
-                                <p>{t('gameUI.keepExploring')}</p>
+                                <p>{tNested('gameUI.keepExploring')}</p>
                             )}
                         </div>
                     );
                 })}
             </div>
-            <button className="secondary-button" onClick={onBack} style={{ marginTop: '2rem' }}>{t('gameUI.back')}</button>
+            <button className="secondary-button" onClick={onBack} style={{ marginTop: '2rem' }}>{tNested('gameUI.back')}</button>
         </div>
     );
 };
 const PerksScreen = ({ unlockedPerks, onBack }) => {
-    const { t, tNested } = useTranslation();
+    const { tNested } = useTranslation();
     return (
         <div className="screen-container">
-            <h1>{t('screens.perks.title')}</h1>
+            <h1>{tNested('screens.perks.title')}</h1>
             <p style={{ textAlign: 'center', color: 'var(--light-text)', maxWidth: '600px', marginBottom: '2rem' }}>
-                {t('screens.perks.description')}
+                {tNested('screens.perks.description')}
             </p>
             <div className="screen-grid">
                 {speciesData.map(species => {
@@ -153,39 +153,39 @@ const PerksScreen = ({ unlockedPerks, onBack }) => {
                             <div className="emoji">{isUnlocked ? species.emoji : '🔒'}</div>
                             <h3>{perkName}</h3>
                             <p className="description">{perkDescription}</p>
-                            {!isUnlocked && <p>{t('gameUI.masterToUnlock')} {speciesName} {t('gameUI.to unlock')}</p>}
+                            {!isUnlocked && <p>{tNested('gameUI.masterToUnlock')} {speciesName} {tNested('gameUI.to unlock')}</p>}
                         </div>
                     );
                 })}
             </div>
-            <button className="secondary-button" onClick={onBack} style={{ marginTop: '2rem' }}>{t('gameUI.back')}</button>
+            <button className="secondary-button" onClick={onBack} style={{ marginTop: '2rem' }}>{tNested('gameUI.back')}</button>
         </div>
     );
 };
 const ResultModal = ({ message, onClose }) => {
-    const { t } = useTranslation();
+    const { tNested } = useTranslation();
     return (
         <div className="modal-overlay" onClick={onClose}>
             <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                 <h2>{message}</h2>
-                <button className="explore-button" onClick={onClose} style={{marginTop: '1rem'}}>{t('gameUI.ok')}</button>
+                <button className="explore-button" onClick={onClose} style={{marginTop: '1rem'}}>{tNested('gameUI.ok')}</button>
             </div>
         </div>
     );
 };
 const EncounterModal = ({ encounter, isRadiant, onLog, onRelease }) => {
-    const { t, tNested } = useTranslation();
+    const { tNested } = useTranslation();
     const speciesName = tNested(`species.${encounter.id}.name`) || encounter.name;
-    const radiantPrefix = isRadiant ? `${t('gameUI.radiant')} ` : '';
+    const radiantPrefix = isRadiant ? `${tNested('gameUI.radiant')} ` : '';
     return (
         <div className="modal-overlay">
             <div className="modal-content">
                 <div className="emoji" style={{ filter: isRadiant ? 'drop-shadow(0 0 1rem #fde047)' : 'none' }}>{encounter.emoji}</div>
-                <h2>A {radiantPrefix}{speciesName} {t('gameUI.appeared')}</h2>
-                <p>{t('gameUI.whatWillYouDo')}</p>
+                <h2>A {radiantPrefix}{speciesName} {tNested('gameUI.appeared')}</h2>
+                <p>{tNested('gameUI.whatWillYouDo')}</p>
                 <div className="button-group">
-                    <button className="explore-button" onClick={onLog}>{t('gameUI.logIt')}</button>
-                    <button className="danger-button" onClick={onRelease}>{t('gameUI.letItGo')}</button>
+                    <button className="explore-button" onClick={onLog}>{tNested('gameUI.logIt')}</button>
+                    <button className="danger-button" onClick={onRelease}>{tNested('gameUI.letItGo')}</button>
                 </div>
             </div>
         </div>
@@ -408,11 +408,11 @@ export default function App() {
                         <div className="status-indicators">
                             <div className="status-item">
                                 <span className="status-icon">🌍</span>
-                                <span className="status-text">{t('status.location')}</span>
+                            <span className="status-text">{tNested('status.location')}</span>
                             </div>
                             <div className="status-item">
                                 <span className="status-icon">🔬</span>
-                                <span className="status-text">{t('status.researchActive')}</span>
+                            <span className="status-text">{tNested('status.researchActive')}</span>
                             </div>
                         </div>
                         <LanguageSwitcher />
@@ -437,8 +437,8 @@ export default function App() {
                         </div>
                     )}
                     <div className="game-status">
-                        <p>{t('gameUI.time')}: {t(`gameUI.timeValues.${playerState.gameTime}`)}</p>
-                        <p>{t('gameUI.weather')}: {t(`gameUI.weatherValues.${playerState.weather}`)}</p>
+                        <p>{tNested('gameUI.time')}: {tNested(`gameUI.timeValues.${playerState.gameTime}`)}</p>
+                        <p>{tNested('gameUI.weather')}: {tNested(`gameUI.weatherValues.${playerState.weather}`)}</p>
                     </div>
                 </div>
                 <div className="control-panel">
@@ -446,12 +446,12 @@ export default function App() {
                         <>
                             <div className="button-group">
                                 <button className="explore-button" onClick={handleAnalyzeBiome} disabled={isScanning || isFocusing}>
-                                    {isScanning ? t('gameUI.scanningBiome') : isFocusing ? t('gameUI.focusing') : t('exploreButton')}
+                                    {isScanning ? tNested('gameUI.scanningBiome') : isFocusing ? tNested('gameUI.focusing') : t('exploreButton')}
                                 </button>
                             </div>
                             <div className="button-group">
-                                <button className="secondary-button" onClick={() => setCurrentScreen('ecoLog')}>{t('gameUI.viewEcoLog')}</button>
-                                <button className="secondary-button" onClick={() => setCurrentScreen('perks')}>{t('gameUI.viewPerks')}</button>
+                                <button className="secondary-button" onClick={() => setCurrentScreen('ecoLog')}>{tNested('gameUI.viewEcoLog')}</button>
+                                <button className="secondary-button" onClick={() => setCurrentScreen('perks')}>{tNested('gameUI.viewPerks')}</button>
                             </div>
                             {lastEncounterMessage && <p style={{ color: 'var(--light-text)', marginTop: '1rem' }}>{lastEncounterMessage}</p>}
                         </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,7 +117,7 @@ const EcoLogComponent = ({ ecoLog, onBack }) => {
                             {isDiscovered ? (
                                 <>
                                     <p>{t('gameUI.level')}: {entry.researchLevel} / {MAX_RESEARCH_LEVEL}</p>
-                                    <p>{t('gameUI.rarity')}: {species.rarity}</p>
+                                    <p>{t('gameUI.rarity')}: {t(`rarity.${species.rarity}`)}</p>
                                     <div className="xp-bar-container" title={`XP: ${entry.researchXp} / ${XP_PER_LEVEL}`}>
                                         <div className="xp-bar-fill" style={{ width: `${(entry.researchXp / XP_PER_LEVEL) * 100}%` }}></div>
                                     </div>
@@ -176,11 +176,12 @@ const ResultModal = ({ message, onClose }) => {
 const EncounterModal = ({ encounter, isRadiant, onLog, onRelease }) => {
     const { t, tNested } = useTranslation();
     const speciesName = tNested(`species.${encounter.id}.name`) || encounter.name;
+    const radiantPrefix = isRadiant ? `${t('gameUI.radiant')} ` : '';
     return (
         <div className="modal-overlay">
             <div className="modal-content">
                 <div className="emoji" style={{ filter: isRadiant ? 'drop-shadow(0 0 1rem #fde047)' : 'none' }}>{encounter.emoji}</div>
-                <h2>A {isRadiant && 'Radiant '}{speciesName} {t('gameUI.appeared')}</h2>
+                <h2>A {radiantPrefix}{speciesName} {t('gameUI.appeared')}</h2>
                 <p>{t('gameUI.whatWillYouDo')}</p>
                 <div className="button-group">
                     <button className="explore-button" onClick={onLog}>{t('gameUI.logIt')}</button>
@@ -407,11 +408,11 @@ export default function App() {
                         <div className="status-indicators">
                             <div className="status-item">
                                 <span className="status-icon">🌍</span>
-                                <span className="status-text">Itatiaia NP</span>
+                                <span className="status-text">{t('status.location')}</span>
                             </div>
                             <div className="status-item">
                                 <span className="status-icon">🔬</span>
-                                <span className="status-text">Research Active</span>
+                                <span className="status-text">{t('status.researchActive')}</span>
                             </div>
                         </div>
                         <LanguageSwitcher />
@@ -436,8 +437,8 @@ export default function App() {
                         </div>
                     )}
                     <div className="game-status">
-                        <p>{t('gameUI.time')}: {playerState.gameTime.charAt(0).toUpperCase() + playerState.gameTime.slice(1)}</p>
-                        <p>{t('gameUI.weather')}: {playerState.weather.charAt(0).toUpperCase() + playerState.weather.slice(1)}</p>
+                        <p>{t('gameUI.time')}: {t(`gameUI.timeValues.${playerState.gameTime}`)}</p>
+                        <p>{t('gameUI.weather')}: {t(`gameUI.weatherValues.${playerState.weather}`)}</p>
                     </div>
                 </div>
                 <div className="control-panel">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -274,7 +274,7 @@ export default function App() {
                 if (!playerState.unlockedPerks.includes(perkId)) {
                     setTimeout(() => {
                         const perkName = tNested(`perks.${species.masteryPerk.id}.name`) || species.masteryPerk.name;
-                        setResultMessage(`${t('gameUI.mastery')} ${t('gameUI.youLearned')} '${perkName}'.`);
+                        setResultMessage(`${tNested('gameUI.mastery')} ${tNested('gameUI.youLearned')} '${perkName}'.`);
                         setModalState(s => ({ ...s, result: true }));
                         setPlayerState(p => ({...p, unlockedPerks: [...p.unlockedPerks, perkId]}));
                     }, 500);
@@ -282,7 +282,7 @@ export default function App() {
             }
             return { ...prevLog, [speciesId]: { researchLevel: newLevel, researchXp: newXp } };
         });
-    }, [playerState.unlockedPerks, t, tNested]);
+    }, [playerState.unlockedPerks, tNested]);
 
     const closeAllModals = () => {
         setModalState({ encounter: false, quiz: false, result: false });
@@ -363,7 +363,7 @@ export default function App() {
             if (isFocusing) {
                 setIsFocusing(false);
                 setHotspot(null);
-                setLastEncounterMessage(t('gameUI.noBioSignatures'));
+                setLastEncounterMessage(tNested('gameUI.noBioSignatures'));
             }
         }, FOCUS_TIMEOUT);
         const currentScannerWindow = scannerWindowRef.current;
@@ -372,7 +372,7 @@ export default function App() {
             currentScannerWindow?.removeEventListener('mousemove', handleMouseMove);
             clearTimeout(focusTimeout);
         };
-    }, [isFocusing, hotspot, playerState.unlockedPerks, t]);
+    }, [isFocusing, hotspot, playerState.unlockedPerks, tNested]);
 
     const handleGameResult = (wasSuccessful) => {
         setResultMessage("");
@@ -381,12 +381,12 @@ export default function App() {
             grantXp(activeEncounter.id, xpGain);
             if (!resultMessage.includes("Mastery!")) {
                 const speciesName = tNested(`species.${activeEncounter.id}.name`) || activeEncounter.name;
-                setResultMessage(`${t('gameUI.success')} ${speciesName} ${t('gameUI.hasBeenLogged')}`);
+                setResultMessage(`${tNested('gameUI.success')} ${speciesName} ${tNested('gameUI.hasBeenLogged')}`);
                 setModalState({ encounter: false, quiz: false, result: true });
             }
         } else {
             const speciesName = tNested(`species.${activeEncounter.id}.name`) || activeEncounter.name;
-            setResultMessage(`${t('gameUI.ohNo')} ${speciesName} ${t('gameUI.fled')}`);
+            setResultMessage(`${tNested('gameUI.ohNo')} ${speciesName} ${tNested('gameUI.fled')}`);
             setModalState({ encounter: false, quiz: false, result: true });
         }
     };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,6 +38,7 @@
     "logIt": "Log It",
     "letItGo": "Let It Go",
     "appeared": "appeared!",
+    "radiant": "Radiant",
     "whatWillYouDo": "What will you do?",
     "success": "Success!",
     "hasBeenLogged": "has been logged.",
@@ -51,6 +52,8 @@
     "analyzeBiome": "Analyze Biome",
     "time": "Time",
     "weather": "Weather",
+    "timeValues": { "day": "Day", "night": "Night" },
+    "weatherValues": { "clear": "Clear", "rainy": "Rainy" },
     "level": "Level",
     "rarity": "Rarity",
     "undiscovered": "Undiscovered",
@@ -58,6 +61,8 @@
     "masterToUnlock": "Master the",
     "to unlock": "to unlock."
   },
+  "rarity": { "common": "Common", "uncommon": "Uncommon", "rare": "Rare" },
+  "status": { "location": "Itatiaia NP", "researchActive": "Research Active" },
   "species": {
     "onca_pintada": {
       "name": "Jaguar",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -38,6 +38,7 @@
     "logIt": "Registrar",
     "letItGo": "Dejar Ir",
     "appeared": "¡apareció!",
+    "radiant": "Radiante",
     "whatWillYouDo": "¿Qué harás?",
     "success": "¡Éxito!",
     "hasBeenLogged": "ha sido registrado.",
@@ -51,6 +52,8 @@
     "analyzeBiome": "Analizar Bioma",
     "time": "Tiempo",
     "weather": "Clima",
+    "timeValues": { "day": "Día", "night": "Noche" },
+    "weatherValues": { "clear": "Despejado", "rainy": "Lluvioso" },
     "level": "Nivel",
     "rarity": "Rareza",
     "undiscovered": "No Descubierto",
@@ -58,6 +61,8 @@
     "masterToUnlock": "Domina el",
     "to unlock": "para desbloquear."
   },
+  "rarity": { "common": "Común", "uncommon": "Poco común", "rare": "Raro" },
+  "status": { "location": "PN Itatiaia", "researchActive": "Investigación Activa" },
   "species": {
     "onca_pintada": {
       "name": "Jaguar",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -38,6 +38,7 @@
     "logIt": "Enregistrer",
     "letItGo": "Laisser Partir",
     "appeared": "est apparu !",
+    "radiant": "Radieux",
     "whatWillYouDo": "Que ferez-vous ?",
     "success": "Succès !",
     "hasBeenLogged": "a été enregistré.",
@@ -51,6 +52,8 @@
     "analyzeBiome": "Analyser le Biome",
     "time": "Temps",
     "weather": "Météo",
+    "timeValues": { "day": "Jour", "night": "Nuit" },
+    "weatherValues": { "clear": "Dégagé", "rainy": "Pluvieux" },
     "level": "Niveau",
     "rarity": "Rareté",
     "undiscovered": "Non Découvert",
@@ -58,6 +61,8 @@
     "masterToUnlock": "Maîtrisez le",
     "to unlock": "pour débloquer."
   },
+  "rarity": { "common": "Commun", "uncommon": "Peu commun", "rare": "Rare" },
+  "status": { "location": "PN d'Itatiaia", "researchActive": "Recherche active" },
   "species": {
     "onca_pintada": {
       "name": "Jaguar",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -38,6 +38,7 @@
     "logIt": "Registrar",
     "letItGo": "Deixar Ir",
     "appeared": "apareceu!",
+    "radiant": "Radiante",
     "whatWillYouDo": "O que você fará?",
     "success": "Sucesso!",
     "hasBeenLogged": "foi registrado.",
@@ -51,6 +52,8 @@
     "analyzeBiome": "Analisar Bioma",
     "time": "Tempo",
     "weather": "Clima",
+    "timeValues": { "day": "Dia", "night": "Noite" },
+    "weatherValues": { "clear": "Céu limpo", "rainy": "Chuvoso" },
     "level": "Nível",
     "rarity": "Raridade",
     "undiscovered": "Não Descoberto",
@@ -58,6 +61,8 @@
     "masterToUnlock": "Domine o",
     "to unlock": "para desbloquear."
   },
+  "rarity": { "common": "Comum", "uncommon": "Incomum", "rare": "Raro" },
+  "status": { "location": "Parque Nacional de Itatiaia", "researchActive": "Pesquisa Ativa" },
   "species": {
     "onca_pintada": {
       "name": "Onça-pintada",


### PR DESCRIPTION
## Summary
- Route hardcoded UI texts through i18n (buttons, status bar, rarity labels)
- Add missing translation keys in en/pt/es/fr (radiant, time/weather values, rarity, status)
- Keeps lint and build green

## Test plan
- Switch languages and verify Eco-Log, Perks, encounter modal, and status bar reflect the selected language