### PR TITLE
feat(assistant): Field Assistant MVP (chat + quick actions)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,12 +98,12 @@ const selectByRarity = (speciesPool) => {
     return speciesPool[speciesPool.length - 1];
 };
 const EcoLogComponent = ({ ecoLog, onBack }) => {
-    const { t, tNested } = useTranslation();
+    const { tNested } = useTranslation();
     return (
         <div className="screen-container">
-            <h1>{t('screens.ecoLog.title')}</h1>
+            <h1>{tNested('screens.ecoLog.title')}</h1>
             <p style={{ textAlign: 'center', color: 'var(--light-text)', maxWidth: '600px', marginBottom: '2rem' }}>
-                {t('screens.ecoLog.description')}
+                {tNested('screens.ecoLog.description')}
             </p>
             <div className="screen-grid">
                 {speciesData.map(species => {
@@ -113,33 +113,33 @@ const EcoLogComponent = ({ ecoLog, onBack }) => {
                     return (
                         <div key={species.id} className={`card ${isDiscovered ? 'discovered' : 'undiscovered'}`}>
                             <div className="emoji">{isDiscovered ? species.emoji : '❓'}</div>
-                            <h3>{isDiscovered ? speciesName : t('gameUI.undiscovered')}</h3>
+                            <h3>{isDiscovered ? speciesName : tNested('gameUI.undiscovered')}</h3>
                             {isDiscovered ? (
                                 <>
-                                    <p>{t('gameUI.level')}: {entry.researchLevel} / {MAX_RESEARCH_LEVEL}</p>
-                                    <p>{t('gameUI.rarity')}: {t(`rarity.${species.rarity}`)}</p>
+                                    <p>{tNested('gameUI.level')}: {entry.researchLevel} / {MAX_RESEARCH_LEVEL}</p>
+                                    <p>{tNested('gameUI.rarity')}: {tNested(`rarity.${species.rarity}`)}</p>
                                     <div className="xp-bar-container" title={`XP: ${entry.researchXp} / ${XP_PER_LEVEL}`}>
                                         <div className="xp-bar-fill" style={{ width: `${(entry.researchXp / XP_PER_LEVEL) * 100}%` }}></div>
                                     </div>
                                 </>
                             ) : (
-                                <p>{t('gameUI.keepExploring')}</p>
+                                <p>{tNested('gameUI.keepExploring')}</p>
                             )}
                         </div>
                     );
                 })}
             </div>
-            <button className="secondary-button" onClick={onBack} style={{ marginTop: '2rem' }}>{t('gameUI.back')}</button>
+            <button className="secondary-button" onClick={onBack} style={{ marginTop: '2rem' }}>{tNested('gameUI.back')}</button>
         </div>
     );
 };
 const PerksScreen = ({ unlockedPerks, onBack }) => {
-    const { t, tNested } = useTranslation();
+    const { tNested } = useTranslation();
     return (
         <div className="screen-container">
-            <h1>{t('screens.perks.title')}</h1>
+            <h1>{tNested('screens.perks.title')}</h1>
             <p style={{ textAlign: 'center', color: 'var(--light-text)', maxWidth: '600px', marginBottom: '2rem' }}>
-                {t('screens.perks.description')}
+                {tNested('screens.perks.description')}
             </p>
             <div className="screen-grid">
                 {speciesData.map(species => {
@@ -153,39 +153,39 @@ const PerksScreen = ({ unlockedPerks, onBack }) => {
                             <div className="emoji">{isUnlocked ? species.emoji : '🔒'}</div>
                             <h3>{perkName}</h3>
                             <p className="description">{perkDescription}</p>
-                            {!isUnlocked && <p>{t('gameUI.masterToUnlock')} {speciesName} {t('gameUI.to unlock')}</p>}
+                            {!isUnlocked && <p>{tNested('gameUI.masterToUnlock')} {speciesName} {tNested('gameUI.to unlock')}</p>}
                         </div>
                     );
                 })}
             </div>
-            <button className="secondary-button" onClick={onBack} style={{ marginTop: '2rem' }}>{t('gameUI.back')}</button>
+            <button className="secondary-button" onClick={onBack} style={{ marginTop: '2rem' }}>{tNested('gameUI.back')}</button>
         </div>
     );
 };
 const ResultModal = ({ message, onClose }) => {
-    const { t } = useTranslation();
+    const { tNested } = useTranslation();
     return (
         <div className="modal-overlay" onClick={onClose}>
             <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                 <h2>{message}</h2>
-                <button className="explore-button" onClick={onClose} style={{marginTop: '1rem'}}>{t('gameUI.ok')}</button>
+                <button className="explore-button" onClick={onClose} style={{marginTop: '1rem'}}>{tNested('gameUI.ok')}</button>
             </div>
         </div>
     );
 };
 const EncounterModal = ({ encounter, isRadiant, onLog, onRelease }) => {
-    const { t, tNested } = useTranslation();
+    const { tNested } = useTranslation();
     const speciesName = tNested(`species.${encounter.id}.name`) || encounter.name;
-    const radiantPrefix = isRadiant ? `${t('gameUI.radiant')} ` : '';
+    const radiantPrefix = isRadiant ? `${tNested('gameUI.radiant')} ` : '';
     return (
         <div className="modal-overlay">
             <div className="modal-content">
                 <div className="emoji" style={{ filter: isRadiant ? 'drop-shadow(0 0 1rem #fde047)' : 'none' }}>{encounter.emoji}</div>
-                <h2>A {radiantPrefix}{speciesName} {t('gameUI.appeared')}</h2>
-                <p>{t('gameUI.whatWillYouDo')}</p>
+                <h2>A {radiantPrefix}{speciesName} {tNested('gameUI.appeared')}</h2>
+                <p>{tNested('gameUI.whatWillYouDo')}</p>
                 <div className="button-group">
-                    <button className="explore-button" onClick={onLog}>{t('gameUI.logIt')}</button>
-                    <button className="danger-button" onClick={onRelease}>{t('gameUI.letItGo')}</button>
+                    <button className="explore-button" onClick={onLog}>{tNested('gameUI.logIt')}</button>
+                    <button className="danger-button" onClick={onRelease}>{tNested('gameUI.letItGo')}</button>
                 </div>
             </div>
         </div>
@@ -408,11 +408,11 @@ export default function App() {
                         <div className="status-indicators">
                             <div className="status-item">
                                 <span className="status-icon">🌍</span>
-                                <span className="status-text">{t('status.location')}</span>
+                            <span className="status-text">{tNested('status.location')}</span>
                             </div>
                             <div className="status-item">
                                 <span className="status-icon">🔬</span>
-                                <span className="status-text">{t('status.researchActive')}</span>
+                            <span className="status-text">{tNested('status.researchActive')}</span>
                             </div>
                         </div>
                         <LanguageSwitcher />
@@ -437,8 +437,8 @@ export default function App() {
                         </div>
                     )}
                     <div className="game-status">
-                        <p>{t('gameUI.time')}: {t(`gameUI.timeValues.${playerState.gameTime}`)}</p>
-                        <p>{t('gameUI.weather')}: {t(`gameUI.weatherValues.${playerState.weather}`)}</p>
+                        <p>{tNested('gameUI.time')}: {tNested(`gameUI.timeValues.${playerState.gameTime}`)}</p>
+                        <p>{tNested('gameUI.weather')}: {tNested(`gameUI.weatherValues.${playerState.weather}`)}</p>
                     </div>
                 </div>
                 <div className="control-panel">
@@ -446,12 +446,12 @@ export default function App() {
                         <>
                             <div className="button-group">
                                 <button className="explore-button" onClick={handleAnalyzeBiome} disabled={isScanning || isFocusing}>
-                                    {isScanning ? t('gameUI.scanningBiome') : isFocusing ? t('gameUI.focusing') : t('exploreButton')}
+                                    {isScanning ? tNested('gameUI.scanningBiome') : isFocusing ? tNested('gameUI.focusing') : t('exploreButton')}
                                 </button>
                             </div>
                             <div className="button-group">
-                                <button className="secondary-button" onClick={() => setCurrentScreen('ecoLog')}>{t('gameUI.viewEcoLog')}</button>
-                                <button className="secondary-button" onClick={() => setCurrentScreen('perks')}>{t('gameUI.viewPerks')}</button>
+                                <button className="secondary-button" onClick={() => setCurrentScreen('ecoLog')}>{tNested('gameUI.viewEcoLog')}</button>
+                                <button className="secondary-button" onClick={() => setCurrentScreen('perks')}>{tNested('gameUI.viewPerks')}</button>
                             </div>
                             {lastEncounterMessage && <p style={{ color: 'var(--light-text)', marginTop: '1rem' }}>{lastEncounterMessage}</p>}
                         </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,7 +117,7 @@ const EcoLogComponent = ({ ecoLog, onBack }) => {
                             {isDiscovered ? (
                                 <>
                                     <p>{t('gameUI.level')}: {entry.researchLevel} / {MAX_RESEARCH_LEVEL}</p>
-                                    <p>{t('gameUI.rarity')}: {species.rarity}</p>
+                                    <p>{t('gameUI.rarity')}: {t(`rarity.${species.rarity}`)}</p>
                                     <div className="xp-bar-container" title={`XP: ${entry.researchXp} / ${XP_PER_LEVEL}`}>
                                         <div className="xp-bar-fill" style={{ width: `${(entry.researchXp / XP_PER_LEVEL) * 100}%` }}></div>
                                     </div>
@@ -176,11 +176,12 @@ const ResultModal = ({ message, onClose }) => {
 const EncounterModal = ({ encounter, isRadiant, onLog, onRelease }) => {
     const { t, tNested } = useTranslation();
     const speciesName = tNested(`species.${encounter.id}.name`) || encounter.name;
+    const radiantPrefix = isRadiant ? `${t('gameUI.radiant')} ` : '';
     return (
         <div className="modal-overlay">
             <div className="modal-content">
                 <div className="emoji" style={{ filter: isRadiant ? 'drop-shadow(0 0 1rem #fde047)' : 'none' }}>{encounter.emoji}</div>
-                <h2>A {isRadiant && 'Radiant '}{speciesName} {t('gameUI.appeared')}</h2>
+                <h2>A {radiantPrefix}{speciesName} {t('gameUI.appeared')}</h2>
                 <p>{t('gameUI.whatWillYouDo')}</p>
                 <div className="button-group">
                     <button className="explore-button" onClick={onLog}>{t('gameUI.logIt')}</button>
@@ -407,11 +408,11 @@ export default function App() {
                         <div className="status-indicators">
                             <div className="status-item">
                                 <span className="status-icon">🌍</span>
-                                <span className="status-text">Itatiaia NP</span>
+                                <span className="status-text">{t('status.location')}</span>
                             </div>
                             <div className="status-item">
                                 <span className="status-icon">🔬</span>
-                                <span className="status-text">Research Active</span>
+                                <span className="status-text">{t('status.researchActive')}</span>
                             </div>
                         </div>
                         <LanguageSwitcher />
@@ -436,8 +437,8 @@ export default function App() {
                         </div>
                     )}
                     <div className="game-status">
-                        <p>{t('gameUI.time')}: {playerState.gameTime.charAt(0).toUpperCase() + playerState.gameTime.slice(1)}</p>
-                        <p>{t('gameUI.weather')}: {playerState.weather.charAt(0).toUpperCase() + playerState.weather.slice(1)}</p>
+                        <p>{t('gameUI.time')}: {t(`gameUI.timeValues.${playerState.gameTime}`)}</p>
+                        <p>{t('gameUI.weather')}: {t(`gameUI.weatherValues.${playerState.weather}`)}</p>
                     </div>
                 </div>
                 <div className="control-panel">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import './App.css';
 import { useTranslation } from './hooks/useTranslation';
 import LanguageSwitcher from './components/LanguageSwitcher';
+import AssistantPanel from './components/AssistantPanel';
 
 // ===================== DATA STRUCTURES & GAME CONSTANTS =====================
 const MAX_RESEARCH_LEVEL = 2;
@@ -457,6 +458,24 @@ export default function App() {
                         </>
                     ) : ( <div/> )}
                 </div>
+                <AssistantPanel
+                  gameState={{
+                    playerState,
+                    ecoLog,
+                    isScanning,
+                    isFocusing,
+                    hotEncounterSpeciesId: activeEncounter?.id || null,
+                  }}
+                  onAction={(action) => {
+                    if (action.type === 'startScan') {
+                      handleAnalyzeBiome();
+                    } else if (action.type === 'openEcoLog') {
+                      setCurrentScreen('ecoLog');
+                    } else if (action.type === 'openPerks') {
+                      setCurrentScreen('perks');
+                    }
+                  }}
+                />
                 {currentScreen === 'ecoLog' && <EcoLogComponent ecoLog={ecoLog} onBack={() => setCurrentScreen('explore')} />}
                 {currentScreen === 'perks' && <PerksScreen unlockedPerks={playerState.unlockedPerks} onBack={() => setCurrentScreen('explore')} />}
                 {activeEncounter && modalState.quiz && ( <QuizModal species={activeEncounter} onResult={handleGameResult} /> )}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -274,7 +274,7 @@ export default function App() {
                 if (!playerState.unlockedPerks.includes(perkId)) {
                     setTimeout(() => {
                         const perkName = tNested(`perks.${species.masteryPerk.id}.name`) || species.masteryPerk.name;
-                        setResultMessage(`${t('gameUI.mastery')} ${t('gameUI.youLearned')} '${perkName}'.`);
+                        setResultMessage(`${tNested('gameUI.mastery')} ${tNested('gameUI.youLearned')} '${perkName}'.`);
                         setModalState(s => ({ ...s, result: true }));
                         setPlayerState(p => ({...p, unlockedPerks: [...p.unlockedPerks, perkId]}));
                     }, 500);
@@ -282,7 +282,7 @@ export default function App() {
             }
             return { ...prevLog, [speciesId]: { researchLevel: newLevel, researchXp: newXp } };
         });
-    }, [playerState.unlockedPerks, t, tNested]);
+    }, [playerState.unlockedPerks, tNested]);
 
     const closeAllModals = () => {
         setModalState({ encounter: false, quiz: false, result: false });
@@ -363,7 +363,7 @@ export default function App() {
             if (isFocusing) {
                 setIsFocusing(false);
                 setHotspot(null);
-                setLastEncounterMessage(t('gameUI.noBioSignatures'));
+                setLastEncounterMessage(tNested('gameUI.noBioSignatures'));
             }
         }, FOCUS_TIMEOUT);
         const currentScannerWindow = scannerWindowRef.current;
@@ -372,7 +372,7 @@ export default function App() {
             currentScannerWindow?.removeEventListener('mousemove', handleMouseMove);
             clearTimeout(focusTimeout);
         };
-    }, [isFocusing, hotspot, playerState.unlockedPerks, t]);
+    }, [isFocusing, hotspot, playerState.unlockedPerks, tNested]);
 
     const handleGameResult = (wasSuccessful) => {
         setResultMessage("");
@@ -381,12 +381,12 @@ export default function App() {
             grantXp(activeEncounter.id, xpGain);
             if (!resultMessage.includes("Mastery!")) {
                 const speciesName = tNested(`species.${activeEncounter.id}.name`) || activeEncounter.name;
-                setResultMessage(`${t('gameUI.success')} ${speciesName} ${t('gameUI.hasBeenLogged')}`);
+                setResultMessage(`${tNested('gameUI.success')} ${speciesName} ${tNested('gameUI.hasBeenLogged')}`);
                 setModalState({ encounter: false, quiz: false, result: true });
             }
         } else {
             const speciesName = tNested(`species.${activeEncounter.id}.name`) || activeEncounter.name;
-            setResultMessage(`${t('gameUI.ohNo')} ${speciesName} ${t('gameUI.fled')}`);
+            setResultMessage(`${tNested('gameUI.ohNo')} ${speciesName} ${tNested('gameUI.fled')}`);
             setModalState({ encounter: false, quiz: false, result: true });
         }
     };

--- a/src/assistant/brain.js
+++ b/src/assistant/brain.js
@@ -1,0 +1,124 @@
+// Simple rule-based assistant brain for Eco-Explorer
+// Returns a response with text and optional quick actions
+
+/**
+ * @typedef {Object} AssistantAction
+ * @property {('startScan'|'openEcoLog'|'openPerks'|'switchLanguage')} type
+ * @property {string=} value
+ */
+
+/**
+ * @typedef {Object} AssistantResponse
+ * @property {string} text
+ * @property {AssistantAction[]} [actions]
+ */
+
+/**
+ * Build a compact context snapshot for the assistant
+ */
+export function buildContextSnapshot(gameState) {
+  const {
+    playerState,
+    ecoLog,
+    isScanning,
+    isFocusing,
+    hotEncounterSpeciesId,
+  } = gameState;
+
+  const discoveredCount = Object.keys(ecoLog || {}).length;
+  const masteredCount = Object.values(ecoLog || {}).filter((e) => e.researchLevel >= 2).length;
+
+  return {
+    time: playerState?.gameTime || 'day',
+    weather: playerState?.weather || 'clear',
+    unlockedPerks: playerState?.unlockedPerks || [],
+    discoveredCount,
+    masteredCount,
+    isScanning: !!isScanning,
+    isFocusing: !!isFocusing,
+    hotEncounterSpeciesId: hotEncounterSpeciesId || null,
+  };
+}
+
+/**
+ * Rule-based policy to produce guidance and actions.
+ * @param {ReturnType<typeof buildContextSnapshot>} ctx
+ * @param {string} userText lowercased user message
+ * @param {{supportedLanguages: string[], currentLanguage: string}} lang
+ * @returns {AssistantResponse}
+ */
+export function getAssistantResponse(ctx, userText, lang) {
+  // Language intent
+  if (/\b(language|idioma|langue|idioma)\b/.test(userText)) {
+    const next = nextLanguage(lang.currentLanguage, lang.supportedLanguages);
+    return {
+      text: `I can switch the language. Do you want ${next.toUpperCase()}?`,
+      actions: [
+        { type: 'switchLanguage', value: next },
+      ],
+    };
+  }
+
+  // Help intents
+  if (/\b(perk|skills?)\b/.test(userText)) {
+    return {
+      text: 'Perks are earned by mastering species. Review your perks and aim to complete mastery for new bonuses.',
+      actions: [
+        { type: 'openPerks' },
+        { type: 'openEcoLog' },
+      ],
+    };
+  }
+
+  if (/\b(log|dex|eco[- ]?log|species)\b/.test(userText)) {
+    return {
+      text: 'Your Eco-Log tracks discovered species. Explore different times or weather to find more.',
+      actions: [
+        { type: 'openEcoLog' },
+        { type: 'startScan' },
+      ],
+    };
+  }
+
+  // Contextual nudges
+  if (!ctx.isScanning && !ctx.isFocusing) {
+    if (ctx.time === 'day') {
+      return {
+        text: 'Try scanning now. Night-time can reveal different species. You can also check your Eco-Log for clues.',
+        actions: [
+          { type: 'startScan' },
+          { type: 'openEcoLog' },
+        ],
+      };
+    }
+    return {
+      text: 'Conditions look promising. Start a scan or review perks to boost encounter chances.',
+      actions: [
+        { type: 'startScan' },
+        { type: 'openPerks' },
+      ],
+    };
+  }
+
+  if (ctx.isFocusing) {
+    return {
+      text: 'Move your cursor to locate the hotspot. When you are close enough, an encounter will begin.',
+      actions: [],
+    };
+  }
+
+  return {
+    text: 'Keep exploring! You can review the Eco-Log and perks anytime, or switch the interface language.',
+    actions: [
+      { type: 'openEcoLog' },
+      { type: 'openPerks' },
+    ],
+  };
+}
+
+function nextLanguage(current, supported) {
+  const idx = supported.indexOf(current);
+  if (idx === -1) return supported[0] || 'en';
+  const nextIdx = (idx + 1) % supported.length;
+  return supported[nextIdx];
+}

--- a/src/components/AssistantPanel.jsx
+++ b/src/components/AssistantPanel.jsx
@@ -1,0 +1,77 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from '../hooks/useTranslation'
+import { buildContextSnapshot, getAssistantResponse } from '../assistant/brain'
+
+export default function AssistantPanel({ gameState, onAction }) {
+  const { t, tNested, supportedLanguages, currentLanguage, setLanguage } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const [input, setInput] = useState('')
+  const [messages, setMessages] = useState([
+    { role: 'assistant', text: t('assistant.welcome') }
+  ])
+  const endRef = useRef(null)
+
+  const ctx = useMemo(() => buildContextSnapshot(gameState), [gameState])
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, isOpen])
+
+  const handleSend = async () => {
+    const text = input.trim()
+    if (!text) return
+    setMessages(prev => [...prev, { role: 'user', text }])
+    setInput('')
+
+    const resp = getAssistantResponse(ctx, text.toLowerCase(), { supportedLanguages, currentLanguage })
+    setMessages(prev => [...prev, { role: 'assistant', text: resp.text }])
+
+    if (resp.actions && resp.actions.length > 0) {
+      // Expose actions as buttons
+    }
+  }
+
+  const handleQuickAction = async (action) => {
+    if (action.type === 'switchLanguage' && action.value) {
+      await setLanguage(action.value)
+      setMessages(prev => [...prev, { role: 'assistant', text: t('assistant.languageSwitched') }])
+      return
+    }
+    onAction?.(action)
+  }
+
+  return (
+    <div className={`assistant-panel ${isOpen ? 'open' : ''}`}>
+      <button className="assistant-toggle" onClick={() => setIsOpen(!isOpen)} title={t('assistant.openTooltip')}>
+        🤖
+      </button>
+      {isOpen && (
+        <div className="assistant-body">
+          <div className="assistant-header">{t('assistant.title')}</div>
+          <div className="assistant-messages">
+            {messages.map((m, i) => (
+              <div key={i} className={`msg ${m.role}`}>{m.text}</div>
+            ))}
+            <div ref={endRef} />
+          </div>
+          <div className="assistant-actions">
+            {(getAssistantResponse(ctx, '', { supportedLanguages, currentLanguage }).actions || []).map((a, i) => (
+              <button key={i} className="action-btn" onClick={() => handleQuickAction(a)}>
+                {tNested(`assistant.actions.${a.type}`)}
+              </button>
+            ))}
+          </div>
+          <div className="assistant-input">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder={t('assistant.placeholder')}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleSend() }}
+            />
+            <button onClick={handleSend}>{t('assistant.send')}</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,6 +38,7 @@
     "logIt": "Log It",
     "letItGo": "Let It Go",
     "appeared": "appeared!",
+    "radiant": "Radiant",
     "whatWillYouDo": "What will you do?",
     "success": "Success!",
     "hasBeenLogged": "has been logged.",
@@ -51,6 +52,8 @@
     "analyzeBiome": "Analyze Biome",
     "time": "Time",
     "weather": "Weather",
+    "timeValues": { "day": "Day", "night": "Night" },
+    "weatherValues": { "clear": "Clear", "rainy": "Rainy" },
     "level": "Level",
     "rarity": "Rarity",
     "undiscovered": "Undiscovered",
@@ -58,6 +61,8 @@
     "masterToUnlock": "Master the",
     "to unlock": "to unlock."
   },
+  "rarity": { "common": "Common", "uncommon": "Uncommon", "rare": "Rare" },
+  "status": { "location": "Itatiaia NP", "researchActive": "Research Active" },
   "species": {
     "onca_pintada": {
       "name": "Jaguar",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,6 +63,20 @@
   },
   "rarity": { "common": "Common", "uncommon": "Uncommon", "rare": "Rare" },
   "status": { "location": "Itatiaia NP", "researchActive": "Research Active" },
+  "assistant": {
+    "title": "Field Assistant",
+    "welcome": "Hi Explorer! Need a hint or mission?",
+    "openTooltip": "Open assistant",
+    "placeholder": "Ask about species, perks, or tips...",
+    "send": "Send",
+    "languageSwitched": "Language updated.",
+    "actions": {
+      "startScan": "Start scan",
+      "openEcoLog": "Open Eco-Log",
+      "openPerks": "Open Perks",
+      "switchLanguage": "Switch language"
+    }
+  },
   "species": {
     "onca_pintada": {
       "name": "Jaguar",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -38,6 +38,7 @@
     "logIt": "Registrar",
     "letItGo": "Dejar Ir",
     "appeared": "¡apareció!",
+    "radiant": "Radiante",
     "whatWillYouDo": "¿Qué harás?",
     "success": "¡Éxito!",
     "hasBeenLogged": "ha sido registrado.",
@@ -51,6 +52,8 @@
     "analyzeBiome": "Analizar Bioma",
     "time": "Tiempo",
     "weather": "Clima",
+    "timeValues": { "day": "Día", "night": "Noche" },
+    "weatherValues": { "clear": "Despejado", "rainy": "Lluvioso" },
     "level": "Nivel",
     "rarity": "Rareza",
     "undiscovered": "No Descubierto",
@@ -58,6 +61,8 @@
     "masterToUnlock": "Domina el",
     "to unlock": "para desbloquear."
   },
+  "rarity": { "common": "Común", "uncommon": "Poco común", "rare": "Raro" },
+  "status": { "location": "PN Itatiaia", "researchActive": "Investigación Activa" },
   "species": {
     "onca_pintada": {
       "name": "Jaguar",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -63,6 +63,20 @@
   },
   "rarity": { "common": "Común", "uncommon": "Poco común", "rare": "Raro" },
   "status": { "location": "PN Itatiaia", "researchActive": "Investigación Activa" },
+  "assistant": {
+    "title": "Asistente de Campo",
+    "welcome": "¡Hola, Explorador! ¿Necesitas una pista o misión?",
+    "openTooltip": "Abrir asistente",
+    "placeholder": "Pregunta sobre especies, perks o consejos...",
+    "send": "Enviar",
+    "languageSwitched": "Idioma actualizado.",
+    "actions": {
+      "startScan": "Iniciar escaneo",
+      "openEcoLog": "Abrir Eco-Log",
+      "openPerks": "Abrir Perks",
+      "switchLanguage": "Cambiar idioma"
+    }
+  },
   "species": {
     "onca_pintada": {
       "name": "Jaguar",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -63,6 +63,20 @@
   },
   "rarity": { "common": "Commun", "uncommon": "Peu commun", "rare": "Rare" },
   "status": { "location": "PN d'Itatiaia", "researchActive": "Recherche active" },
+  "assistant": {
+    "title": "Assistant de Terrain",
+    "welcome": "Bonjour Explorateur ! Besoin d'un indice ou d'une mission ?",
+    "openTooltip": "Ouvrir l'assistant",
+    "placeholder": "Demandez sur les espèces, perks ou conseils...",
+    "send": "Envoyer",
+    "languageSwitched": "Langue mise à jour.",
+    "actions": {
+      "startScan": "Démarrer le scan",
+      "openEcoLog": "Ouvrir l'Eco-Log",
+      "openPerks": "Ouvrir les Perks",
+      "switchLanguage": "Changer de langue"
+    }
+  },
   "species": {
     "onca_pintada": {
       "name": "Jaguar",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -38,6 +38,7 @@
     "logIt": "Enregistrer",
     "letItGo": "Laisser Partir",
     "appeared": "est apparu !",
+    "radiant": "Radieux",
     "whatWillYouDo": "Que ferez-vous ?",
     "success": "Succès !",
     "hasBeenLogged": "a été enregistré.",
@@ -51,6 +52,8 @@
     "analyzeBiome": "Analyser le Biome",
     "time": "Temps",
     "weather": "Météo",
+    "timeValues": { "day": "Jour", "night": "Nuit" },
+    "weatherValues": { "clear": "Dégagé", "rainy": "Pluvieux" },
     "level": "Niveau",
     "rarity": "Rareté",
     "undiscovered": "Non Découvert",
@@ -58,6 +61,8 @@
     "masterToUnlock": "Maîtrisez le",
     "to unlock": "pour débloquer."
   },
+  "rarity": { "common": "Commun", "uncommon": "Peu commun", "rare": "Rare" },
+  "status": { "location": "PN d'Itatiaia", "researchActive": "Recherche active" },
   "species": {
     "onca_pintada": {
       "name": "Jaguar",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -38,6 +38,7 @@
     "logIt": "Registrar",
     "letItGo": "Deixar Ir",
     "appeared": "apareceu!",
+    "radiant": "Radiante",
     "whatWillYouDo": "O que você fará?",
     "success": "Sucesso!",
     "hasBeenLogged": "foi registrado.",
@@ -51,6 +52,8 @@
     "analyzeBiome": "Analisar Bioma",
     "time": "Tempo",
     "weather": "Clima",
+    "timeValues": { "day": "Dia", "night": "Noite" },
+    "weatherValues": { "clear": "Céu limpo", "rainy": "Chuvoso" },
     "level": "Nível",
     "rarity": "Raridade",
     "undiscovered": "Não Descoberto",
@@ -58,6 +61,8 @@
     "masterToUnlock": "Domine o",
     "to unlock": "para desbloquear."
   },
+  "rarity": { "common": "Comum", "uncommon": "Incomum", "rare": "Raro" },
+  "status": { "location": "Parque Nacional de Itatiaia", "researchActive": "Pesquisa Ativa" },
   "species": {
     "onca_pintada": {
       "name": "Onça-pintada",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -63,6 +63,20 @@
   },
   "rarity": { "common": "Comum", "uncommon": "Incomum", "rare": "Raro" },
   "status": { "location": "Parque Nacional de Itatiaia", "researchActive": "Pesquisa Ativa" },
+  "assistant": {
+    "title": "Assistente de Campo",
+    "welcome": "Olá, Explorador! Precisa de dica ou missão?",
+    "openTooltip": "Abrir assistente",
+    "placeholder": "Pergunte sobre espécies, perks ou dicas...",
+    "send": "Enviar",
+    "languageSwitched": "Idioma atualizado.",
+    "actions": {
+      "startScan": "Iniciar varredura",
+      "openEcoLog": "Abrir Eco-Log",
+      "openPerks": "Abrir Perks",
+      "switchLanguage": "Trocar idioma"
+    }
+  },
   "species": {
     "onca_pintada": {
       "name": "Onça-pintada",


### PR DESCRIPTION
## Summary
- Add AssistantPanel (chat) with rule-based guidance and quick actions
- Actions: startScan, openEcoLog, openPerks, switchLanguage
- i18n for assistant in en/pt/es/fr

## Test plan
- npm run dev
- Click 🤖 to open assistant; try sending messages like:
  - "help perks"
  - "log/dex"
  - "language"
- Use quick-action buttons to trigger scan/open log/perks