### PR TITLE
feat: daily streak bonus and badge (+5% at 3+ days)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,7 +62,7 @@
     "to unlock": "to unlock."
   },
   "rarity": { "common": "Common", "uncommon": "Uncommon", "rare": "Rare" },
-  "status": { "location": "Itatiaia NP", "researchActive": "Research Active" },
+  "status": { "location": "Itatiaia NP", "researchActive": "Research Active", "streak": "Streak", "days": "days" },
   "hints": {
     "noBio": "No strong bio-signatures here. Try scanning again.",
     "tryRain": "Rain may attract different species.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -62,7 +62,7 @@
     "to unlock": "para desbloquear."
   },
   "rarity": { "common": "Común", "uncommon": "Poco común", "rare": "Raro" },
-  "status": { "location": "PN Itatiaia", "researchActive": "Investigación Activa" },
+  "status": { "location": "PN Itatiaia", "researchActive": "Investigación Activa", "streak": "Racha", "days": "días" },
   "hints": {
     "noBio": "Sin biofirmas fuertes aquí. Intenta escanear de nuevo.",
     "tryRain": "La lluvia puede atraer especies diferentes.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -62,7 +62,7 @@
     "to unlock": "pour débloquer."
   },
   "rarity": { "common": "Commun", "uncommon": "Peu commun", "rare": "Rare" },
-  "status": { "location": "PN d'Itatiaia", "researchActive": "Recherche active" },
+  "status": { "location": "PN d'Itatiaia", "researchActive": "Recherche active", "streak": "Série", "days": "jours" },
   "hints": {
     "noBio": "Aucune bio-signature forte ici. Réessayez un scan.",
     "tryRain": "La pluie peut attirer des espèces différentes.",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -62,7 +62,7 @@
     "to unlock": "para desbloquear."
   },
   "rarity": { "common": "Comum", "uncommon": "Incomum", "rare": "Raro" },
-  "status": { "location": "Parque Nacional de Itatiaia", "researchActive": "Pesquisa Ativa" },
+  "status": { "location": "Parque Nacional de Itatiaia", "researchActive": "Pesquisa Ativa", "streak": "Sequência", "days": "dias" },
   "hints": {
     "noBio": "Sem bioassinaturas fortes aqui. Tente escanear novamente.",
     "tryRain": "A chuva pode atrair espécies diferentes.",


### PR DESCRIPTION
## Summary
- Add daily streak tracking using localStorage
- Grant +5% encounter chance at 3+ days
- Show streak badge in header (localized)
- Update ROADMAP items

## Test plan
- npm run dev
- Reload across days (or tweak localStorage key `ee-last-login`) to simulate
- Verify streak count increments and encounter chance increases (+0.05)