### PR TITLE
feat: shareable Eco‑Log card (PNG export)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,7 +23,7 @@
   - Contextual hint above Scan; rotating objective with progress bar
 - [x] Eco‑Dex card improvements
   - Rarity icon, best time/weather, one “fun fact,” progress to next perk
-- [ ] Shareable log card
+- [x] Shareable log card
   - Download a small PNG of a species card for social
 
 ## Phase plan

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -125,7 +125,7 @@ const EcoLogComponent = ({ ecoLog, onBack }) => {
                     const isDiscovered = !!entry;
                     const speciesName = tNested(`species.${species.id}.name`) || species.name;
                     return (
-                        <div key={species.id} className={`card ${isDiscovered ? 'discovered' : 'undiscovered'}`}>
+                        <div key={species.id} className={`card ${isDiscovered ? 'discovered' : 'undiscovered'}`} data-speciesid={species.id}>
                             <div className="emoji">{isDiscovered ? species.emoji : '❓'}</div>
                             <h3>{isDiscovered ? speciesName : tNested('gameUI.undiscovered')}</h3>
                             {isDiscovered ? (
@@ -135,6 +135,7 @@ const EcoLogComponent = ({ ecoLog, onBack }) => {
                                     <p>{tNested('gameUI.time')}: {tNested(`gameUI.timeValues.${tNested(`species.${species.id}.bestTime`)}`)}</p>
                                     <p>{tNested('gameUI.weather')}: {tNested(`gameUI.weatherValues.${tNested(`species.${species.id}.bestWeather`)}`)}</p>
                                     <p style={{ fontStyle: 'italic' }}>{tNested(`species.${species.id}.funFact`)}</p>
+                                    <ShareCardButton speciesId={species.id} label={tNested('share.card')} />
                                     <div className="xp-bar-container" title={`XP: ${entry.researchXp} / ${XP_PER_LEVEL}`}>
                                         <div className="xp-bar-fill" style={{ width: `${(entry.researchXp / XP_PER_LEVEL) * 100}%` }}></div>
                                     </div>
@@ -150,6 +151,19 @@ const EcoLogComponent = ({ ecoLog, onBack }) => {
         </div>
     );
 };
+
+function ShareCardButton({ speciesId, label }) {
+    const handleShare = async () => {
+        const card = document.querySelector(`.card[data-speciesid="${speciesId}"]`);
+        if (!card) return;
+        const { captureElementToPng, downloadDataUrl } = await import('./utils/cardShare.js');
+        const dataUrl = await captureElementToPng(card);
+        downloadDataUrl(`eco-${speciesId}.png`, dataUrl);
+    };
+    return (
+        <button className="secondary-button" onClick={handleShare} style={{ marginTop: '0.5rem' }}>{label}</button>
+    );
+}
 const PerksScreen = ({ unlockedPerks, onBack }) => {
     const { tNested } = useTranslation();
     return (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -158,6 +158,7 @@
       "description": "These passive skills are earned by mastering a species' research. They provide permanent advantages."
     }
   },
+  "share": { "card": "Share card" },
   "quizzes": {
     "onca_pintada": [
       {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -158,6 +158,7 @@
       "description": "Estas habilidades pasivas se obtienen dominando la investigación de una especie. Proporcionan ventajas permanentes."
     }
   },
+  "share": { "card": "Compartir tarjeta" },
   "quizzes": {
     "onca_pintada": [
       {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -158,6 +158,7 @@
       "description": "Ces compétences passives sont gagnées en maîtrisant la recherche d'une espèce. Elles fournissent des avantages permanents."
     }
   },
+  "share": { "card": "Partager la carte" },
   "quizzes": {
     "onca_pintada": [
       {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -158,6 +158,7 @@
       "description": "Essas habilidades passivas são conquistadas dominando a pesquisa de uma espécie. Elas fornecem vantagens permanentes."
     }
   },
+  "share": { "card": "Compartilhar card" },
   "quizzes": {
     "onca_pintada": [
       {

--- a/src/utils/cardShare.js
+++ b/src/utils/cardShare.js
@@ -1,0 +1,33 @@
+export async function captureElementToPng(element) {
+  const scale = 2
+  const rect = element.getBoundingClientRect()
+  const canvas = document.createElement('canvas')
+  canvas.width = rect.width * scale
+  canvas.height = rect.height * scale
+  const ctx = canvas.getContext('2d')
+  ctx.scale(scale, scale)
+  // Simple draw: background and text snapshot
+  ctx.fillStyle = '#0c0a09'
+  ctx.fillRect(0, 0, rect.width, rect.height)
+  // Rasterize DOM minimally (emoji + texts)
+  const emoji = element.querySelector('.emoji')?.textContent || '🌿'
+  const title = element.querySelector('h3')?.textContent || ''
+  const lines = Array.from(element.querySelectorAll('p')).map(p => p.textContent)
+  ctx.fillStyle = '#fff'
+  ctx.font = '48px sans-serif'
+  ctx.fillText(emoji, 20, 60)
+  ctx.font = '20px sans-serif'
+  ctx.fillText(title, 80, 60)
+  ctx.font = '14px sans-serif'
+  lines.slice(0, 4).forEach((line, i) => ctx.fillText(line || '', 20, 100 + i * 22))
+  return canvas.toDataURL('image/png')
+}
+
+export function downloadDataUrl(filename, dataUrl) {
+  const a = document.createElement('a')
+  a.href = dataUrl
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+}


### PR DESCRIPTION
## Summary
- Add Share card button to Eco‑Log discovered species
- Exports a simple PNG snapshot (emoji, title, key lines) via canvas

## Test plan
- npm run dev
- Open Eco‑Log; click Share card on a discovered species; PNG downloads